### PR TITLE
Use a Docker Redis cluster when testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,18 @@
 language: erlang
+
+services:
+  - docker
+
 otp_release:
    - 21.0
    - 20.3
    - 19.3
    - 18.3
-   - 17.5
 
-install: 
-   - make travis-install
-   - wget -c https://github.com/erlang/rebar3/releases/download/3.6.2/rebar3 && chmod +x rebar3
+notifications:
+  email: false
+
+install:
+   - wget -c https://github.com/erlang/rebar3/releases/download/3.13.1/rebar3 && chmod +x rebar3
+
 script: REBAR=./rebar3 make travis-run

--- a/README.md
+++ b/README.md
@@ -11,12 +11,15 @@ eredis_cluster is a wrapper for eredis to support cluster mode of redis 3.0.0+
 - Improve test suite to demonstrate the case where redis cluster is crashing,
 resharding, recovering...
 
-## Compilation && Test
+## Compilation and tests
 
-The directory contains a Makefile and rebar3
+The directory contains a Makefile that uses rebar3.
+Setup a Redis cluster and start the tests using following commands:
 
-	make
-	make test
+    make
+    make start
+    make test
+    make stop
 
 ## Configuration
 
@@ -104,7 +107,7 @@ eredis_cluster:update_hash_field("abc", "efg", Fun).
 
 %% Eval script, both script and hash are necessary to execute the command,
 %% the script hash should be precomputed at compile time otherwise, it will
-%% execute it at each request. Could be solved by using a macro though.  
+%% execute it at each request. Could be solved by using a macro though.
 Script = "return redis.call('set', KEYS[1], ARGV[1]);",
 ScriptHash = "4bf5e0d8612687699341ea7db19218e83f77b7cf",
 eredis_cluster:eval(Script, ScriptHash, ["abc"], ["123"]).


### PR DESCRIPTION
Start redis instances for the tests using docker to avoid cleanups.
The containers uses host network that is similar as before this change.

Also updated rebar3 to 3.13 which deprecates OTP17 in travis