### PR TITLE
Let get_all_pools/0 return unique pool names

### DIFF
--- a/src/eredis_cluster_monitor.erl
+++ b/src/eredis_cluster_monitor.erl
@@ -57,8 +57,8 @@ get_state_version(State) ->
 get_all_pools() ->
     State = get_state(),
     SlotsMapList = tuple_to_list(State#state.slots_maps),
-    [SlotsMap#slots_map.node#node.pool || SlotsMap <- SlotsMapList,
-        SlotsMap#slots_map.node =/= undefined].
+    lists:usort([SlotsMap#slots_map.node#node.pool || SlotsMap <- SlotsMapList,
+                    SlotsMap#slots_map.node =/= undefined]).
 
 %% =============================================================================
 %% @doc Get cluster pool by slot. Optionally, a memoized State can be provided


### PR DESCRIPTION
This correct issues like when performing a DBSIZE query using qa/1 on all nodes.
After a resharding/scale-out/scale-in the query will result in duplicate requests to nodes with more that one slot-range.
This makes sure we only query each master once.