### PR TITLE
Improved configurations handling

### DIFF
--- a/include/eredis_cluster.hrl
+++ b/include/eredis_cluster.hrl
@@ -19,6 +19,7 @@
 -record(node, {
     address :: string(),
     port :: integer(),
+    options :: options(),
     pool :: atom()
 }).
 

--- a/rebar.config
+++ b/rebar.config
@@ -31,6 +31,6 @@
             , {preprocess, true}
             ]}.
 
-{deps, [ {eredis, {git, "git://github.com/Nordix/eredis.git", {ref, "45128ec"}}}
+{deps, [ {eredis, {git, "git://github.com/Nordix/eredis.git", {ref, "f69d9e1"}}}
        , {poolboy, "1.5.2"}
        ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,7 +1,7 @@
 {"1.1.0",
 [{<<"eredis">>,
   {git,"git://github.com/Nordix/eredis.git",
-       {ref,"45128ec264ae1e17d952b74d4a40702872249e73"}},
+       {ref,"f69d9e116222b524ff647cfec46793d59abf30e3"}},
   0},
  {<<"poolboy">>,{pkg,<<"poolboy">>,<<"1.5.2">>},0}]}.
 [

--- a/test/eredis_cluster_tls_tests.erl
+++ b/test/eredis_cluster_tls_tests.erl
@@ -15,8 +15,24 @@ connect_test() ->
     ?assertMatch(ok, eredis_cluster:stop()).
 
 get_set_test() ->
-    application:set_env(eredis_cluster, init_nodes, []),
-    ?assertMatch(ok, eredis_cluster:start()),
+    start(),
+    connect_tls(),
+
+    ?assertEqual({ok, <<"OK">>}, eredis_cluster:q(["SET", "key", "value"])),
+    ?assertEqual({ok, <<"value">>}, eredis_cluster:q(["GET", "key"])),
+    ?assertEqual({ok, undefined}, eredis_cluster:q(["GET","nonexists"])),
+
+    ?assertMatch(ok, eredis_cluster:stop()).
+
+options_override_test() ->
+    start(),
+
+    %% Application configs has a faulty cert
+    application:set_env(eredis_cluster, tls, [{cacertfile, "faulty.crt"},
+                                              {certfile,   "faulty.crt"},
+                                              {keyfile,    "faulty.key"}]),
+
+    %% Connect using a correct cert via connect/2
     Dir = filename:join([code:lib_dir(eredis_cluster), "test", "tls"]),
     Options = [{tls, [{cacertfile, filename:join([Dir, "ca.crt"])},
                       {certfile,   filename:join([Dir, "client.crt"])},
@@ -25,8 +41,53 @@ get_set_test() ->
                                   {"127.0.0.1", 31002}], Options),
     ?assertMatch(ok, Res),
 
-    ?assertEqual({ok, <<"OK">>}, eredis_cluster:q(["SET", "key", "value"])),
-    ?assertEqual({ok, <<"value">>}, eredis_cluster:q(["GET","key"])),
-    ?assertEqual({ok, undefined}, eredis_cluster:q(["GET","nonexists"])),
+    Key = "Key123",
+    ?assertEqual({ok, <<"OK">>}, eredis_cluster:q(["SET", Key, "value"])),
+    ?assertEqual({ok, <<"value">>}, eredis_cluster:q(["GET", Key])),
 
     ?assertMatch(ok, eredis_cluster:stop()).
+
+options_changed_test() ->
+    start(),
+    connect_tls(),
+    Key = "Key123",
+    ?assertEqual({ok, <<"OK">>}, eredis_cluster:q(["SET", Key, "value"])),
+    ?assertEqual({ok, <<"value">>}, eredis_cluster:q(["GET", Key])),
+
+    %% Change TLS options via setenv
+    Dir = filename:join([code:lib_dir(eredis_cluster), "test", "tls"]),
+    application:set_env(eredis_cluster, tls, [{cacertfile, filename:join([Dir, "faulty.crt"])},
+                                              {certfile,   filename:join([Dir, "faulty.crt"])},
+                                              {keyfile,    filename:join([Dir, "faulty.key"])}]),
+
+    State = eredis_cluster_monitor:get_state(),
+    Version = eredis_cluster_monitor:get_state_version(State),
+    eredis_cluster_monitor:refresh_mapping(Version),
+
+    %% Change back
+    Dir = filename:join([code:lib_dir(eredis_cluster), "test", "tls"]),
+    application:set_env(eredis_cluster, tls, [{cacertfile, filename:join([Dir, "ca.crt"])},
+                                              {certfile,   filename:join([Dir, "client.crt"])},
+                                              {keyfile,    filename:join([Dir, "client.key"])}]),
+
+    State = eredis_cluster_monitor:get_state(),
+    Version = eredis_cluster_monitor:get_state_version(State),
+    eredis_cluster_monitor:refresh_mapping(Version),
+
+    ?assertEqual({ok, <<"value">>}, eredis_cluster:q(["GET", Key])),
+
+    ?assertMatch(ok, eredis_cluster:stop()).
+
+start() ->
+    application:unset_env(eredis_cluster, init_nodes),
+    application:unset_env(eredis_cluster, password),
+    ?assertMatch(ok, eredis_cluster:start()).
+
+connect_tls() ->
+    Dir = filename:join([code:lib_dir(eredis_cluster), "test", "tls"]),
+    application:set_env(eredis_cluster, tls, [{cacertfile, filename:join([Dir, "ca.crt"])},
+                                              {certfile,   filename:join([Dir, "client.crt"])},
+                                              {keyfile,    filename:join([Dir, "client.key"])}]),
+    Res = eredis_cluster:connect([{"127.0.0.1", 31001},
+                                  {"127.0.0.1", 31002}]),
+    ?assertMatch(ok, Res).


### PR DESCRIPTION
Erlang application configurations are now used to set options, but it possible to override using connect/2.
When slots-maps are updated the configs are checked as well, and if configs have changed the connection is re-established using the new configuration.

Upgraded eredis dependency version.