### PR TITLE
Retry when pool is full

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -46,6 +46,6 @@
 {profiles, [{
              test, [{deps,
                      [{fakeredis_cluster,
-                       {git, "git://github.com/bjosv/fakeredis_cluster.git", {ref, "77024cf"}}}]
+                       {git, "git://github.com/bjosv/fakeredis_cluster.git", {ref, "73e3e2f"}}}]
                     }]
             }]}.

--- a/src/eredis_cluster_pool_worker.erl
+++ b/src/eredis_cluster_pool_worker.erl
@@ -36,6 +36,8 @@ init(Args) ->
 
     {ok, #state{conn=Conn}}.
 
+query(full, _Commands) ->
+    {error, full};
 query(Worker, Commands) ->
     gen_server:call(Worker, {'query', Commands}).
 

--- a/test/eredis_cluster_fakeredis_SUITE.erl
+++ b/test/eredis_cluster_fakeredis_SUITE.erl
@@ -10,6 +10,7 @@
 %% Test cases
 -export([ t_connect/1
         , t_connect_tls/1
+        , t_pool_full/1
         , t_redis_crash/1
         ]).
 
@@ -69,6 +70,53 @@ t_connect_tls(Config) when is_list(Config) ->
     ?assertEqual({ok, <<"OK">>}, eredis_cluster:q(["SET", "key", "value"])),
     ?assertEqual({ok, <<"value">>}, eredis_cluster:q(["GET", "key"])),
     ?assertEqual({ok, undefined}, eredis_cluster:q(["GET","nonexists"])),
+
+    ?assertMatch(ok, eredis_cluster:stop()).
+
+t_pool_full(Config) when is_list(Config) ->
+    %% Pool size 1 with concurrent queries causes poolboy to return
+    %% 'full' and the query is retried until the first workers are
+    %% done.
+
+    %% Poolboy's checkout timeout is 5000, so we make sure a worker is
+    %% blocked for 6000ms. The time limit for gen_server calls used
+    %% for performing a query is 5000 but it's OK to wait longer for
+    %% the pool. Thus, we need two workers each taking 3000ms to
+    %% block a 3rd worker for 6000ms.
+
+    fakeredis_cluster:start_link([20001, 20002, 20003],
+                                 [{delay, 3000}]),
+
+    application:set_env(eredis_cluster, pool_size, 1),
+    application:set_env(eredis_cluster, pool_max_overflow, 0),
+
+    ct:print("Perform inital connect..."),
+    ?assertMatch(ok, eredis_cluster:connect([{"127.0.0.1", 20001}])),
+
+    ct:print("Test concurrent access..."),
+    MainPid = self(),
+    Fun = fun() ->
+                  ct:print("Test access from process ~p...", [self()]),
+                  ?assertEqual({ok, undefined},
+                               eredis_cluster:q(["GET", "dummy"])),
+                  ct:print("Access from process ~p is done.", [self()]),
+                  MainPid ! done
+          end,
+
+    StartTime = erlang:system_time(millisecond),
+    spawn(Fun),
+    spawn(Fun),
+    spawn(Fun),
+    receive done -> ok after 10000 -> error(timeout) end,
+    receive done -> ok after 10000 -> error(timeout) end,
+    receive done -> ok after 10000 -> error(timeout) end,
+    EndTime = erlang:system_time(millisecond),
+
+    %% The whole sequence must have taken at least 9
+    %% seconds. Otherwise, the delay mechanism in fakeredis doesn't
+    %% work.
+    ct:print("It took ~p milliseconds.", [EndTime - StartTime]),
+    ?assert(EndTime - StartTime >= 9000),
 
     ?assertMatch(ok, eredis_cluster:stop()).
 


### PR DESCRIPTION
Fixes adrienmo#28 and obsoletes PR adrienmo#29.

Retry is implemented for query, but not for query_noreply. Perhaps it should.