### PR TITLE
Pool full

### DIFF
--- a/src/eredis_cluster.erl
+++ b/src/eredis_cluster.erl
@@ -372,6 +372,7 @@ query_noreply(Command, PoolKey) ->
     Transaction = fun(Worker) -> qw_noreply(Worker, Command) end,
     {Pool, _Version} = eredis_cluster_monitor:get_pool_by_slot(Slot),
     eredis_cluster_pool:transaction(Pool, Transaction),
+    %% TODO: Retry if pool is busy?
     ok.
 
 query(_, _, ?REDIS_CLUSTER_REQUEST_TTL) ->
@@ -405,6 +406,10 @@ handle_transaction_result(Result, Version) ->
         %% the next request. We don't need to refresh the slot mapping in this
         %% case
         {error, tcp_closed} ->
+            retry;
+
+        %% Pool is busy
+        {error, pool_busy} ->
             retry;
 
         %% Other TCP issues

--- a/src/eredis_cluster.erl
+++ b/src/eredis_cluster.erl
@@ -372,7 +372,6 @@ query_noreply(Command, PoolKey) ->
     Transaction = fun(Worker) -> qw_noreply(Worker, Command) end,
     {Pool, _Version} = eredis_cluster_monitor:get_pool_by_slot(Slot),
     eredis_cluster_pool:transaction(Pool, Transaction),
-    %% TODO: Retry if pool is full?
     ok.
 
 query(_, _, ?REDIS_CLUSTER_REQUEST_TTL) ->
@@ -406,10 +405,6 @@ handle_transaction_result(Result, Version) ->
         %% the next request. We don't need to refresh the slot mapping in this
         %% case
         {error, tcp_closed} ->
-            retry;
-
-        %% Pool is full
-        {error, full} ->
             retry;
 
         %% Other TCP issues

--- a/src/eredis_cluster_pool.erl
+++ b/src/eredis_cluster_pool.erl
@@ -42,8 +42,9 @@ transaction(PoolName, Transaction) ->
     try
         poolboy:transaction(PoolName, Transaction)
     catch
-        exit:_ ->
-            {error, no_connection}
+        exit:{timeout, _GenServerCall} ->
+            %% Poolboy checkout timeout, but the pool is consistent.
+            {error, pool_busy}
     end.
 
 -spec stop(PoolName::atom()) -> ok.

--- a/src/eredis_cluster_pool_worker.erl
+++ b/src/eredis_cluster_pool_worker.erl
@@ -36,8 +36,6 @@ init(Args) ->
 
     {ok, #state{conn=Conn}}.
 
-query(full, _Commands) ->
-    {error, full};
 query(Worker, Commands) ->
     gen_server:call(Worker, {'query', Commands}).
 


### PR DESCRIPTION
`poolboy:transaction/2` actually doesn't call the transaction fun with 'full'. Poolboy:checkout/3
can return full if called with Block = false, but in poolboy:transaction/2,3, checkout
is called with Block = true.

Instead, if the pool is full (actually empty?), the caller is added to a waiting list
by poolboy and doens't get a reply until a worker returns to the pool. The reply is sent
explicitly using gen_server:reply/2 when a pool worker is checked in back into the pool.
In the meantime, the poolboy:checkout(Pool, true, Timeout) in transaction/3 times out
and an exit exception on the form exit:{timeout,{gen_server,call,_}} is raised.

Normally, you shouldn't catch an exit exception, but in this case it's OK because
poolboy has already caught it, cancelled the waiting for this worker and re-raised the
exception (try-catch-raise) in poolboy:checkout/3.

The exit exception then bubbles out and is caught in eredis_cluster_pool:transaction/2
and converted to {error, no_connection}, which is handled by refreshing the mapping and
then retrying. This commit changes this to {error, pool_busy} and retry without refresh
mapping.