### PR TITLE
Add functions for executing commands on a specific Redis node

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,12 @@ eredis_cluster is a wrapper for eredis to support cluster mode of Redis 3.0.0+
   - `connect/2`:              Connect to init nodes, with options
   - `qa2/1`:                  Query all nodes with re-attempts, returns
                               `[{Node, Result}, ...]`
-  - `q_noreply/1`:            Query a single Redis instance but wont wait for its result
-  - `load_script/1`:          Pre-load script to all Redis instances
-  - `scan/4`:                 Perform a scan command on given Redis instance
-  - `disconnect/1`:           Disconnect from given Redis instances
+  - `qn/2`:                   Query to specific Redis node
+  - `q_noreply/1`:            Query a single Redis node but wont wait for its result
+  - `load_script/1`:          Pre-load script to all Redis nodes
+  - `scan/4`:                 Perform a scan command on given Redis nodes
+  - `disconnect/1`:           Disconnect from given Redis node
+  - `get_all_pools/0`:        Get all pools (one for each Redis node in cluster)
   - `get_pool_by_command/1`:  Get which Redis pool that handles a given command
   - `get_pool_by_key/1`:      Get which Redis pool that handles a given key
   - `eredis_cluster_monitor:get_cluster_nodes/0`: Get cluster nodes information
@@ -39,7 +41,8 @@ eredis_cluster is a wrapper for eredis to support cluster mode of Redis 3.0.0+
     (CLUSTER SLOTS)
 * Changed behaviour:
   - `qa/1`:                   Query all nodes, now with re-attempts
-  - `eredis_cluster_monitor:get_all_pools/0`: Doesn't include duplicates.
+  - `transaction/2`:          The second argument can be a Redis node (pool) or
+                              a key, instead of only a key
 
 ## Usage
 
@@ -151,8 +154,8 @@ retrieve them through the command `CLUSTER SLOTS` at runtime.
 
 ### Configuration parameters
 
-* `init_nodes`: List of Redis instances to fetch cluster information from. Default: `[]`
-* `pool_size`: Number of connected clients to each Redis instance. Default: `10`
+* `init_nodes`: List of Redis nodes to fetch cluster information from. Default: `[]`
+* `pool_size`: Number of connected clients to each Redis node. Default: `10`
 * `pool_max_overflow`: Max number of extra clients that can be started when the pool is exhausted. Default: `0`
 * `password`: Password to use for a Redis cluster configured with `requirepass`. Default: `""` (i.e. AUTH not sent)
 * `socket_options`: Extra socket [options](http://erlang.org/doc/man/gen_tcp.html#type-option). Enables selecting host interface or perf. tuning. Default: `[]`

--- a/include/eredis_cluster.hrl
+++ b/include/eredis_cluster.hrl
@@ -1,6 +1,6 @@
 -type anystring() :: string() | bitstring().
 
--type redis_simple_command() :: [anystring()].
+-type redis_simple_command() :: [anystring() | integer()].
 -type redis_pipeline_command() :: [redis_simple_command()].
 -type redis_command() :: redis_simple_command() | redis_pipeline_command().
 

--- a/src/eredis_cluster_monitor.erl
+++ b/src/eredis_cluster_monitor.erl
@@ -76,6 +76,7 @@ get_state() ->
 get_state_version(State) ->
     State#state.version.
 
+%% @private
 -spec get_all_pools() -> [atom()].
 get_all_pools() ->
     get_all_pools(get_state()).


### PR DESCRIPTION
Add `qn/2`, allow 2nd arg of `transaction/2` to be a pool and add
`get_all_pools/0` (as a wrapper for the internal function with
the same name in eredis_cluster_monitor).

This is a generalization of the mechanism used in `scan/4`, which
is re-implemented using `qn/2`.