### PR TITLE
Add get_cluster_{nodes,slots}/0 wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,8 @@ eredis_cluster is a wrapper for eredis to support cluster mode of Redis 3.0.0+
   - `get_all_pools/0`:        Get all pools (one for each Redis node in cluster)
   - `get_pool_by_command/1`:  Get which Redis pool that handles a given command
   - `get_pool_by_key/1`:      Get which Redis pool that handles a given key
-  - `eredis_cluster_monitor:get_cluster_nodes/0`: Get cluster nodes information
-    list (CLUSTER NODES)
-  - `eredis_cluster_monitor:get_cluster_slots/0`: Get cluster slots information
-    (CLUSTER SLOTS)
+  - `get_cluster_nodes/0`:    Get cluster nodes information (CLUSTER NODES)
+  - `get_cluster_slots/0`:    Get cluster slots information (CLUSTER SLOTS)
 * Changed behaviour:
   - `qa/1`:                   Query all nodes, now with re-attempts
   - `transaction/2`:          The second argument can be a Redis node (pool) or

--- a/src/eredis_cluster.erl
+++ b/src/eredis_cluster.erl
@@ -34,6 +34,9 @@
 %% Specific pools (specific Redis nodes)
 -export([get_pool_by_command/1, get_pool_by_key/1, get_all_pools/0]).
 
+%% Cluster information
+-export([get_cluster_slots/0, get_cluster_nodes/0]).
+
 -ifdef(TEST).
 -export([get_key_slot/1]).
 -export([get_key_from_command/1]).
@@ -918,6 +921,38 @@ get_pool_by_key(Key) ->
 -spec get_all_pools() -> [atom()].
 get_all_pools() ->
     eredis_cluster_monitor:get_all_pools().
+
+%% =============================================================================
+%% @doc Get cluster slots information.
+%%
+%% Fetch information about slots from an already connected node or
+%% from an init node if no nodes are connected.
+%%
+%% Throws an exception if all communication attempts fails.
+%% @end
+%% =============================================================================
+-spec get_cluster_slots() -> [[bitstring() | [bitstring()]]].
+get_cluster_slots() ->
+    eredis_cluster_monitor:get_cluster_slots().
+
+%% =============================================================================
+%% @doc Get cluster nodes information.
+%%
+%% Fetch information about all cluster nodes from an already connected node or
+%% from an init node if no nodes are connected.
+%%
+%% Returns a list of node elements where each node element consists of
+%% following information:
+%% <pre>[id, ip:port@cport, flags, master, ping-sent, pong-recv, config-epoch, link-state, Slot1, ..., SlotN]
+%% </pre>
+%% See [https://redis.io/commands/cluster-nodes#serialization-format] for details.
+%%
+%% Throws an exception if all communication attempts fails.
+%% @end
+%% =============================================================================
+-spec get_cluster_nodes() -> [[bitstring()]].
+get_cluster_nodes() ->
+    eredis_cluster_monitor:get_cluster_nodes().
 
 %% =============================================================================
 %% @doc Return the hash slot from the key

--- a/src/eredis_cluster_monitor.erl
+++ b/src/eredis_cluster_monitor.erl
@@ -14,10 +14,7 @@
 -export([refresh_mapping/1, async_refresh_mapping/1]).
 -export([get_state/0, get_state_version/1]).
 -export([get_pool_by_slot/1, get_pool_by_slot/2]).
--export([get_all_pools/1]).
-
-%% Public API.
--export([get_all_pools/0]).
+-export([get_all_pools/0, get_all_pools/1]).
 -export([get_cluster_slots/0, get_cluster_nodes/0]).
 
 %% gen_server.

--- a/test/eredis_cluster_tests.erl
+++ b/test/eredis_cluster_tests.erl
@@ -335,14 +335,14 @@ basic_test_() ->
 
          { "get cluster nodes",
            fun () ->
-                   ClusterNodes = eredis_cluster_monitor:get_cluster_nodes(),
+                   ClusterNodes = eredis_cluster:get_cluster_nodes(),
                    ?assertNotEqual(0, erlang:length(ClusterNodes))
            end
          },
 
          { "get cluster slots",
            fun () ->
-                   ClusterSlots = eredis_cluster_monitor:get_cluster_slots(),
+                   ClusterSlots = eredis_cluster:get_cluster_slots(),
                    ?assertNotEqual(0, erlang:length(ClusterSlots))
            end
          },
@@ -430,7 +430,7 @@ test_command_support(Command) ->
 
 -spec get_master_nodes() -> [{NodeId::string(), PoolName::atom()}].
 get_master_nodes() ->
-    ClusterNodesInfo = eredis_cluster_monitor:get_cluster_nodes(),
+    ClusterNodesInfo = eredis_cluster:get_cluster_nodes(),
     lists:foldl(fun(Node, Acc) ->
                         case lists:nth(3, Node) of %% <flags>
                             Role when Role == <<"myself,master">>;
@@ -446,7 +446,7 @@ get_master_nodes() ->
 
 -spec get_slave_nodes() -> [{NodeId::string(), Ip::string(), Port::string()}].
 get_slave_nodes() ->
-    ClusterNodesInfo = eredis_cluster_monitor:get_cluster_nodes(),
+    ClusterNodesInfo = eredis_cluster:get_cluster_nodes(),
     lists:foldl(fun(Node, Acc) ->
                         case lists:nth(3, Node) of %% <flags>
                             Role when Role == <<"myself,slave">>;


### PR DESCRIPTION
Adding wrapper functions `get_cluster_{nodes,slots}/0` to the `eredis_cluster` API, which calls corresponding functions in module `eredis_cluster_monitor`