### PR TITLE
Setup single-container test clusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,10 @@
-.PHONY: all compile clean test ut ct xref dialyzer elvis cover coverview edoc help
-.PHONY: start start-tcp start-tls status status-tcp status-tls stop
+.PHONY: all compile clean test ut ct xref dialyzer elvis cover coverview edoc publish
+.PHONY: start status stop
 
 REBAR ?= rebar3
-REDIS_VER ?= 6.0.4
 
-DOCKER_CONF = --net=host -v $(shell pwd)/priv/configs/tls:/conf/tls:ro
-
-# Redis cluster - common configs
-REDIS_CONF = --cluster-enabled yes --cluster-node-timeout 5000 --appendonly yes
-
-# TLS Redis cluster - common configs
-REDIS_TLS_CONF = $(REDIS_CONF) --tls-cluster yes --port 0
-REDIS_TLS_CONF += --tls-ca-cert-file /conf/tls/ca.crt
-REDIS_TLS_CONF += --tls-cert-file /conf/tls/redis.crt
-REDIS_TLS_CONF += --tls-key-file /conf/tls/redis.key
+# When supporting password and TLS; change to grokzen/redis-cluster:X.X.X
+REDIS_CONTAINER ?= bjosv/redis-cluster:6.2.0
 
 all: compile dialyzer xref elvis
 
@@ -79,47 +70,21 @@ publish: edoc
 	fi
 	mix hex.publish
 
-start: start-tcp start-tls
+start:
+	docker run --name redis-cluster -d -e IP=0.0.0.0 -e INITIAL_PORT=30001 \
+	  -p 30001-30006:30001-30006 ${REDIS_CONTAINER}
+	docker run --name redis-cluster-tls -d -e IP=0.0.0.0 -e INITIAL_PORT=31001 \
+	  -p 31001-31006:31001-31006 -e TLS=true \
+	  -v $(shell pwd)/priv/configs/tls/ca.crt:/redis-conf/ca.crt:ro \
+	  -v $(shell pwd)/priv/configs/tls/ca.key:/redis-conf/ca.key:ro \
+	  -v $(shell pwd)/priv/configs/tls/redis.crt:/redis-conf/redis.crt:ro \
+	  -v $(shell pwd)/priv/configs/tls/redis.key:/redis-conf/redis.key:ro \
+	  ${REDIS_CONTAINER}
 
-start-tcp:
-	docker run --name redis-1 -d $(DOCKER_CONF) redis:$(REDIS_VER) redis-server $(REDIS_CONF) --port 30001
-	docker run --name redis-2 -d $(DOCKER_CONF) redis:$(REDIS_VER) redis-server $(REDIS_CONF) --port 30002
-	docker run --name redis-3 -d $(DOCKER_CONF) redis:$(REDIS_VER) redis-server $(REDIS_CONF) --port 30003
-	docker run --name redis-4 -d $(DOCKER_CONF) redis:$(REDIS_VER) redis-server $(REDIS_CONF) --port 30004
-	docker run --name redis-5 -d $(DOCKER_CONF) redis:$(REDIS_VER) redis-server $(REDIS_CONF) --port 30005
-	docker run --name redis-6 -d $(DOCKER_CONF) redis:$(REDIS_VER) redis-server $(REDIS_CONF) --port 30006
-	sleep 5
-	echo 'yes' | docker run --name redis-cli -i --rm $(DOCKER_CONF) redis:$(REDIS_VER) \
-	redis-cli --cluster create \
-	127.0.0.1:30001 127.0.0.1:30002 127.0.0.1:30003 127.0.0.1:30004 127.0.0.1:30005 127.0.0.1:30006 \
-	--cluster-replicas 1
-
-start-tls:
-	docker run --name redis-tls-1 -d $(DOCKER_CONF) redis:$(REDIS_VER) redis-server $(REDIS_TLS_CONF) --tls-port 31001
-	docker run --name redis-tls-2 -d $(DOCKER_CONF) redis:$(REDIS_VER) redis-server $(REDIS_TLS_CONF) --tls-port 31002
-	docker run --name redis-tls-3 -d $(DOCKER_CONF) redis:$(REDIS_VER) redis-server $(REDIS_TLS_CONF) --tls-port 31003
-	docker run --name redis-tls-4 -d $(DOCKER_CONF) redis:$(REDIS_VER) redis-server $(REDIS_TLS_CONF) --tls-port 31004
-	docker run --name redis-tls-5 -d $(DOCKER_CONF) redis:$(REDIS_VER) redis-server $(REDIS_TLS_CONF) --tls-port 31005
-	docker run --name redis-tls-6 -d $(DOCKER_CONF) redis:$(REDIS_VER) redis-server $(REDIS_TLS_CONF) --tls-port 31006
-	sleep 7
-	echo 'yes' | docker run --name redis-cli-tls -i --rm $(DOCKER_CONF) redis:$(REDIS_VER) \
-	redis-cli --cluster create \
-	--tls --cacert /conf/tls/ca.crt --cert /conf/tls/redis.crt --key /conf/tls/redis.key \
-	127.0.0.1:31001 127.0.0.1:31002 127.0.0.1:31003 127.0.0.1:31004 127.0.0.1:31005 127.0.0.1:31006 \
-	--cluster-replicas 1
-
-status: status-tcp status-tls
-
-status-tcp:
-	docker run --name redis-cli -i --rm $(DOCKER_CONF) redis:$(REDIS_VER) \
-	redis-cli -c -p 30001 CLUSTER INFO
-
-status-tls:
-	docker run --name redis-cli -i --rm $(DOCKER_CONF) redis:$(REDIS_VER) \
-	redis-cli -c -p 31001 \
-	--tls --cacert /conf/tls/ca.crt --cert /conf/tls/redis.crt --key /conf/tls/redis.key \
-	CLUSTER INFO
+status:
+	docker exec redis-cluster /redis/src/redis-cli -c -p 30001 CLUSTER INFO
+	docker exec redis-cluster-tls /redis/src/redis-cli -c -p 31001 --tls \
+	  --cacert /redis-conf/ca.crt --cert /redis-conf/redis.crt --key /redis-conf/redis.key CLUSTER INFO
 
 stop:
-	-docker rm -f redis-1 redis-2 redis-3 redis-4 redis-5 redis-6
-	-docker rm -f redis-tls-1 redis-tls-2 redis-tls-3 redis-tls-4 redis-tls-5 redis-tls-6
+	-docker rm -f redis-cluster redis-cluster-tls

--- a/README.md
+++ b/README.md
@@ -100,13 +100,13 @@ eredis_cluster:qk(["FLUSHDB"], "TEST").
 
 The directory contains a Makefile that uses rebar3.
 
-Setup a Redis cluster and start the tests using following commands:
+Setup Redis clusters and start the tests using following commands:
 
 ```bash
 make        # ... or rebar3 compile
-make start  # Start a local Redis cluster using Docker
-make test   # Run tests towards the cluster
-make stop   # Teardown the Redis cluster
+make start  # Start local Redis clusters using Docker
+make test   # Run tests towards the clusters
+make stop   # Teardown the Redis clusters
 ```
 
 ## Configuration


### PR DESCRIPTION
Replacing the test-clusters with single container deployments.
The container from https://github.com/Grokzen/docker-redis-cluster starts 6 Redis instances within a single container and configures them to become a cluster.
The container is already used by project like `redis-py-cluster` and `hiredis-cluster`. 

This enables `eredis_cluster` to be tested on MacOS aswell.