### PR TITLE
Generate working links to the Erlang documentation

### DIFF
--- a/doc/eredis_cluster.md
+++ b/doc/eredis_cluster.md
@@ -221,7 +221,7 @@ connect(InitServers) -&gt; ok
 </code>
 </pre>
 
-<ul class="definitions"><li><code>InitServers = [{Address::string(), Port::<a href="inet.md#type-port_number">inet:port_number()</a>}]</code></li></ul>
+<ul class="definitions"><li><code>InitServers = [{Address::string(), Port::<a href="https://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>}]</code></li></ul>
 
 Connect to a Redis cluster using a set of init nodes.
 
@@ -240,7 +240,7 @@ connect(InitServers, Options) -&gt; ok
 </code>
 </pre>
 
-<ul class="definitions"><li><code>InitServers = [{Address::string(), Port::<a href="inet.md#type-port_number">inet:port_number()</a>}]</code></li><li><code>Options = <a href="#type-options">options()</a></code></li></ul>
+<ul class="definitions"><li><code>InitServers = [{Address::string(), Port::<a href="https://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>}]</code></li><li><code>Options = <a href="#type-options">options()</a></code></li></ul>
 
 Connects to a Redis cluster using a set of init nodes, with options.
 
@@ -256,7 +256,7 @@ connect(Cluster, InitServers, Options) -&gt; ok
 </code>
 </pre>
 
-<ul class="definitions"><li><code>Cluster = atom()</code></li><li><code>InitServers = [{Address::string(), Port::<a href="inet.md#type-port_number">inet:port_number()</a>}]</code></li><li><code>Options = <a href="#type-options">options()</a></code></li></ul>
+<ul class="definitions"><li><code>Cluster = atom()</code></li><li><code>InitServers = [{Address::string(), Port::<a href="https://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>}]</code></li><li><code>Options = <a href="#type-options">options()</a></code></li></ul>
 
 Connects to a Redis cluster using a set of init nodes, with options and
 cluster name.

--- a/rebar.config
+++ b/rebar.config
@@ -32,11 +32,9 @@
 {cover_opts, [verbose]}.
 
 {edoc_opts, [ {doclet, edown_doclet}
-            , {dialyzer_specs, all}
-            , {report_missing_type, true}
-            , {report_type_mismatch, true}
-            , {pretty_print, erl_pp}
+            , {report_missing_types, true}
             , {preprocess, true}
+            , {app_default, "https://www.erlang.org/doc/man"}
             ]}.
 
 {deps, [{eredis, "1.7.0"},


### PR DESCRIPTION
Includes corrections and removal of unused options for edoc.
Documentation is regenerated.