### PR TITLE
Fix CI issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   ci:
     strategy:
+      fail-fast: false
       matrix:
         include: # See https://www.erlang-solutions.com/downloads/
           - otp-version: 25.0.3
@@ -19,12 +20,15 @@ jobs:
           - otp-version: 23.3.4.5
             platform: ubuntu-20.04
             lsb_release: focal
+            rebar3-version: '3.20.0'
           - otp-version: 22.3.4.9
             platform: ubuntu-20.04
             lsb_release: focal
+            rebar3-version: '3.15.2'
           - otp-version: 21.3.8.17
             platform: ubuntu-20.04
             lsb_release: focal
+            rebar3-version: '3.15.2'
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout
@@ -51,10 +55,10 @@ jobs:
           sudo dpkg --install $DEB_NAME
 
       - name: Install compatible rebar3 version
-        if: ${{ startsWith(matrix.otp-version, '21.') || startsWith(matrix.otp-version, '22.') }}
+        if: ${{ matrix.rebar3-version }}
         run: |
           git clone https://github.com/erlang/rebar3.git
-          cd rebar3 && git checkout 3.15.2 && ./bootstrap && ./rebar3 local install
+          cd rebar3 && git checkout ${{ matrix.rebar3-version }} && ./bootstrap && ./rebar3 local install
           echo "$HOME/.cache/rebar3/bin" >> $GITHUB_PATH
 
       - name: Install elvis


### PR DESCRIPTION
Install a compatible `rebar3` version when running CI on `OTP 23`,
and also let all CI jobs finish independently.