### PR TITLE
Fix dialyzer warnings 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ xref:
 	@$(REBAR) xref
 
 dialyzer:
-	@$(REBAR) dialyzer
+	@$(REBAR) as test dialyzer
 
 elvis:
 	@elvis rock

--- a/doc/eredis_cluster.md
+++ b/doc/eredis_cluster.md
@@ -36,7 +36,7 @@ there is no need to use the functions with an explicit Cluster parameter.
 
 
 <pre><code>
-anystring() = string() | bitstring()
+anystring() = string() | binary()
 </code>
 </pre>
 
@@ -96,7 +96,7 @@ redis_command() = <a href="#type-redis_simple_command">redis_simple_command()</a
 
 
 <pre><code>
-redis_error_result() = bitstring() | no_connection | invalid_cluster_command | tcp_closed
+redis_error_result() = binary() | no_connection | invalid_cluster_command | tcp_closed
 </code>
 </pre>
 
@@ -120,7 +120,7 @@ redis_pipeline_command() = [<a href="#type-redis_simple_command">redis_simple_co
 
 
 <pre><code>
-redis_pipeline_result() = [<a href="#type-redis_simple_result">redis_simple_result()</a>]
+redis_pipeline_result() = [<a href="#type-redis_simple_result">redis_simple_result()</a>] | {error, <a href="#type-redis_error_result">redis_error_result()</a>}
 </code>
 </pre>
 
@@ -168,7 +168,7 @@ redis_simple_result() = {ok, <a href="#type-redis_success_result">redis_success_
 
 
 <pre><code>
-redis_success_result() = bitstring() | undefined
+redis_success_result() = binary() | [binary()] | undefined
 </code>
 </pre>
 
@@ -308,7 +308,7 @@ __See also:__ [load_script/1](#load_script-1).
 ### flushdb/0 ###
 
 <pre><code>
-flushdb() -&gt; ok | {error, Reason::bitstring()}
+flushdb() -&gt; ok | {error, <a href="#type-redis_error_result">redis_error_result()</a>}
 </code>
 </pre>
 
@@ -498,7 +498,7 @@ qa(Command) -&gt; Result
 </code>
 </pre>
 
-<ul class="definitions"><li><code>Command = <a href="#type-redis_command">redis_command()</a></code></li><li><code>Result = [<a href="#type-redis_transaction_result">redis_transaction_result()</a>] | {error, no_connection}</code></li></ul>
+<ul class="definitions"><li><code>Command = <a href="#type-redis_command">redis_command()</a></code></li><li><code>Result = [<a href="#type-redis_result">redis_result()</a>] | {error, no_connection}</code></li></ul>
 
 Performs a query on all nodes in the default cluster. When a query to a
 master fails, the mapping is refreshed and the query is retried.
@@ -512,7 +512,7 @@ qa(Cluster, Command) -&gt; Result
 </code>
 </pre>
 
-<ul class="definitions"><li><code>Cluster = atom()</code></li><li><code>Command = <a href="#type-redis_command">redis_command()</a></code></li><li><code>Result = [<a href="#type-redis_transaction_result">redis_transaction_result()</a>] | {error, no_connection}</code></li></ul>
+<ul class="definitions"><li><code>Cluster = atom()</code></li><li><code>Command = <a href="#type-redis_command">redis_command()</a></code></li><li><code>Result = [<a href="#type-redis_result">redis_result()</a>] | {error, no_connection}</code></li></ul>
 
 Performs a query on all nodes in a cluster. When a query to a master
 fails, the mapping is refreshed and the query is retried.
@@ -769,7 +769,7 @@ update_hash_field(Key, Field, UpdateFunction) -&gt; Result
 </code>
 </pre>
 
-<ul class="definitions"><li><code>Key = <a href="#type-anystring">anystring()</a></code></li><li><code>Field = <a href="#type-anystring">anystring()</a></code></li><li><code>UpdateFunction = fun((any()) -&gt; any())</code></li><li><code>Result = {ok, {[any()], any()}} | {error, <a href="#type-redis_error_result">redis_error_result()</a>}</code></li></ul>
+<ul class="definitions"><li><code>Key = <a href="#type-anystring">anystring()</a></code></li><li><code>Field = <a href="#type-anystring">anystring()</a></code></li><li><code>UpdateFunction = fun((any()) -&gt; any())</code></li><li><code>Result = {ok, {any(), any()}} | <a href="#type-optimistic_locking_error_result">optimistic_locking_error_result()</a></code></li></ul>
 
 Update the value of a field stored in a hash by applying the function
 passed in the argument. The operation is done atomically using an optimistic
@@ -786,7 +786,7 @@ update_key(Key, UpdateFunction) -&gt; Result
 </code>
 </pre>
 
-<ul class="definitions"><li><code>Key = <a href="#type-anystring">anystring()</a></code></li><li><code>UpdateFunction = fun((any()) -&gt; any())</code></li><li><code>Result = <a href="#type-redis_transaction_result">redis_transaction_result()</a></code></li></ul>
+<ul class="definitions"><li><code>Key = <a href="#type-anystring">anystring()</a></code></li><li><code>UpdateFunction = fun((any()) -&gt; any())</code></li><li><code>Result = {ok, any()} | <a href="#type-optimistic_locking_error_result">optimistic_locking_error_result()</a></code></li></ul>
 
 Update the value of a key by applying the function passed in the
 argument. The operation is done atomically, using an optimistic locking

--- a/doc/eredis_cluster_monitor.md
+++ b/doc/eredis_cluster_monitor.md
@@ -38,7 +38,7 @@ useful for advanced scenarios.
 ### get_cluster_nodes/0 ###
 
 <pre><code>
-get_cluster_nodes() -&gt; [[bitstring()]]
+get_cluster_nodes() -&gt; [[binary()]]
 </code>
 </pre>
 
@@ -57,7 +57,7 @@ See: https://redis.io/commands/cluster-nodes#serialization-format
 ### get_cluster_nodes/1 ###
 
 <pre><code>
-get_cluster_nodes(Cluster::atom()) -&gt; [[bitstring()]]
+get_cluster_nodes(Cluster::atom()) -&gt; [[binary()]]
 </code>
 </pre>
 
@@ -67,7 +67,7 @@ get_cluster_nodes(Cluster::atom()) -&gt; [[bitstring()]]
 ### get_cluster_slots/0 ###
 
 <pre><code>
-get_cluster_slots() -&gt; [[bitstring() | [bitstring()]]]
+get_cluster_slots() -&gt; [[binary() | [binary()]]]
 </code>
 </pre>
 

--- a/include/eredis_cluster.hrl
+++ b/include/eredis_cluster.hrl
@@ -6,7 +6,7 @@
 
 -type redis_error_result() :: Reason::bitstring() | no_connection
     | invalid_cluster_command | tcp_closed.
--type redis_success_result() :: Result::bitstring() | undefined.
+-type redis_success_result() :: bitstring() | [bitstring()] | undefined.
 -type redis_simple_result() :: {ok, redis_success_result()}
     | {error, redis_error_result()}.
 -type redis_pipeline_result() :: [redis_simple_result()]

--- a/include/eredis_cluster.hrl
+++ b/include/eredis_cluster.hrl
@@ -9,7 +9,8 @@
 -type redis_success_result() :: Result::bitstring() | undefined.
 -type redis_simple_result() :: {ok, redis_success_result()}
     | {error, redis_error_result()}.
--type redis_pipeline_result() :: [redis_simple_result()].
+-type redis_pipeline_result() :: [redis_simple_result()]
+    | {error, redis_error_result()}.
 -type redis_transaction_result() :: {ok, [redis_success_result()]}
     | {ok, undefined} % EXEC reply undefined if the transaction was aborted
     | {error, redis_error_result()}.

--- a/include/eredis_cluster.hrl
+++ b/include/eredis_cluster.hrl
@@ -1,12 +1,12 @@
--type anystring() :: string() | bitstring().
+-type anystring() :: string() | binary().
 
 -type redis_simple_command() :: [anystring() | integer()].
 -type redis_pipeline_command() :: [redis_simple_command()].
 -type redis_command() :: redis_simple_command() | redis_pipeline_command().
 
--type redis_error_result() :: Reason::bitstring() | no_connection
+-type redis_error_result() :: Reason::binary() | no_connection
     | invalid_cluster_command | tcp_closed.
--type redis_success_result() :: bitstring() | [bitstring()] | undefined.
+-type redis_success_result() :: binary() | [binary()] | undefined.
 -type redis_simple_result() :: {ok, redis_success_result()}
     | {error, redis_error_result()}.
 -type redis_pipeline_result() :: [redis_simple_result()]

--- a/rebar.config
+++ b/rebar.config
@@ -45,6 +45,10 @@
                      [{fakeredis_cluster,
                        {git, "https://github.com/Nordix/fakeredis_cluster.git",
                         {ref, "3037e7b"}}}]
+                    },
+                    {dialyzer, [{plt_extra_apps, [eunit,
+                                                  common_test,
+                                                  fakeredis_cluster]}]
                     }]
             },
             {docs, [{deps,

--- a/src/eredis_cluster.erl
+++ b/src/eredis_cluster.erl
@@ -215,7 +215,7 @@ qp(Commands) -> q(Commands).
 %% master fails, the mapping is refreshed and the query is retried.
 -spec qa(Command) -> Result
               when Command :: redis_command(),
-                   Result  :: [redis_transaction_result()] |
+                   Result  :: [redis_result()] |
                               {error, no_connection}.
 qa(Command) -> qa(?default_cluster, Command, 0, []).
 
@@ -224,7 +224,7 @@ qa(Command) -> qa(?default_cluster, Command, 0, []).
 -spec qa(Cluster, Command) -> Result
               when Cluster :: atom(),
                    Command :: redis_command(),
-                   Result  :: [redis_transaction_result()] |
+                   Result  :: [redis_result()] |
                               {error, no_connection}.
 qa(Cluster, Command) -> qa(Cluster, Command, 0, []).
 

--- a/src/eredis_cluster.erl
+++ b/src/eredis_cluster.erl
@@ -498,7 +498,7 @@ transaction_retry_loop(Cluster, Transaction, SlotOrPool, Counter) ->
 %% This is equivalent to calling `qa(["FLUSHDB"])' except for the return value.
 %% @end
 %% =============================================================================
--spec flushdb() -> ok | {error, Reason::bitstring()}.
+-spec flushdb() -> ok | {error, redis_error_result()}.
 flushdb() ->
     case qa(["FLUSHDB"]) of
         Result when is_list(Result) ->
@@ -1053,8 +1053,8 @@ get_all_pools(Cluster) ->
 %% @end
 %% =============================================================================
 -spec get_key_slot(Key::anystring()) -> Slot::integer().
-get_key_slot(Key) when is_bitstring(Key) ->
-    get_key_slot(bitstring_to_list(Key));
+get_key_slot(Key) when is_binary(Key) ->
+    get_key_slot(binary_to_list(Key));
 get_key_slot(Key) ->
     KeyToBeHashed = case string:chr(Key, ${) of
         0 ->
@@ -1092,8 +1092,8 @@ get_key_slot(Key) ->
 %% @end
 %% =============================================================================
 -spec get_key_from_command(redis_command()) -> string() | undefined.
-get_key_from_command([[X|Y]|Z]) when is_bitstring(X) ->
-    get_key_from_command([[bitstring_to_list(X)|Y]|Z]);
+get_key_from_command([[X|Y]|Z]) when is_binary(X) ->
+    get_key_from_command([[binary_to_list(X)|Y]|Z]);
 get_key_from_command([[X|Y]|Z]) when is_list(X) ->
     case string:to_lower(X) of
         "multi" ->
@@ -1101,8 +1101,8 @@ get_key_from_command([[X|Y]|Z]) when is_list(X) ->
         _ ->
             get_key_from_command([X|Y])
     end;
-get_key_from_command([Name | Args]) when is_bitstring(Name) ->
-    get_key_from_command([bitstring_to_list(Name) | Args]);
+get_key_from_command([Name | Args]) when is_binary(Name) ->
+    get_key_from_command([binary_to_list(Name) | Args]);
 get_key_from_command([Name | [Arg|_Rest]=Args]) ->
     case string:to_lower(Name) of
         "info"       -> undefined;

--- a/src/eredis_cluster.erl
+++ b/src/eredis_cluster.erl
@@ -858,7 +858,8 @@ throttle_retries(_) -> timer:sleep(?REDIS_RETRY_DELAY).
 -spec update_key(Key, UpdateFunction) -> Result
               when Key            :: anystring(),
                    UpdateFunction :: fun((any()) -> any()),
-                   Result         :: redis_transaction_result().
+                   Result         :: {ok, any()} |
+                                     optimistic_locking_error_result().
 update_key(Key, UpdateFunction) ->
     UpdateFunction2 = fun(GetResult) ->
         {ok, Var} = GetResult,
@@ -883,8 +884,8 @@ update_key(Key, UpdateFunction) ->
               when Key            :: anystring(),
                    Field          :: anystring(),
                    UpdateFunction :: fun((any()) -> any()),
-                   Result         :: {ok, {[any()], any()}} |
-                                     {error, redis_error_result()}.
+                   Result         :: {ok, {any(), any()}} |
+                                     optimistic_locking_error_result().
 update_hash_field(Key, Field, UpdateFunction) ->
     UpdateFunction2 = fun(GetResult) ->
         {ok, Var} = GetResult,

--- a/src/eredis_cluster_monitor.erl
+++ b/src/eredis_cluster_monitor.erl
@@ -175,12 +175,12 @@ remove_list_elements(Xs, Ys) ->
 %% @doc Get cluster slots information.
 %% @end
 %% =============================================================================
--spec get_cluster_slots() -> [[bitstring() | [bitstring()]]].
+-spec get_cluster_slots() -> [[binary() | [binary()]]].
 get_cluster_slots() ->
     get_cluster_slots(?default_cluster).
 
 %% @private
--spec get_cluster_slots(Cluster :: atom()) -> [[bitstring() | [bitstring()]]].
+-spec get_cluster_slots(Cluster :: atom()) -> [[binary() | [binary()]]].
 get_cluster_slots(Cluster) ->
     State = get_state(Cluster),
     Options = get_current_options(State),
@@ -202,18 +202,18 @@ get_cluster_slots(State, Options) ->
 %% See: https://redis.io/commands/cluster-nodes#serialization-format
 %% @end
 %% =============================================================================
--spec get_cluster_nodes() -> [[bitstring()]].
+-spec get_cluster_nodes() -> [[binary()]].
 get_cluster_nodes() ->
     get_cluster_nodes(?default_cluster).
 
--spec get_cluster_nodes(Cluster :: atom()) -> [[bitstring()]].
+-spec get_cluster_nodes(Cluster :: atom()) -> [[binary()]].
 get_cluster_nodes(Cluster) ->
     State = get_state(Cluster),
     Options = get_current_options(State),
     get_cluster_nodes(State, Options).
 
 %% @private
--spec get_cluster_nodes(State :: #state{}, Options :: options()) -> [[bitstring()]].
+-spec get_cluster_nodes(State :: #state{}, Options :: options()) -> [[binary()]].
 get_cluster_nodes(State, Options) ->
     Query = ["CLUSTER", "NODES"],
     FailFn = fun(_Node) -> "" end, %% No default data to use when query fails
@@ -341,12 +341,12 @@ get_cluster_info_from_connection(Connection, Query, FailFn, Node) ->
     end.
 
 -spec get_cluster_slots_from_single_node(#node{}) ->
-    [[bitstring() | [bitstring()]]].
+    [[binary() | [binary()]]].
 get_cluster_slots_from_single_node(Node) ->
     [[<<"0">>, integer_to_binary(?REDIS_CLUSTER_HASH_SLOTS-1),
     [list_to_binary(Node#node.address), integer_to_binary(Node#node.port)]]].
 
--spec parse_cluster_slots(ClusterInfo::[[bitstring() | [bitstring()]]],
+-spec parse_cluster_slots(ClusterInfo::[[binary() | [binary()]]],
                           Options::options()) -> [#slots_map{}].
 parse_cluster_slots(ClusterInfo, Options) ->
     SlotsMaps = parse_cluster_slots(ClusterInfo, 1, []),

--- a/test/eredis_cluster_fakeredis_SUITE.erl
+++ b/test/eredis_cluster_fakeredis_SUITE.erl
@@ -45,7 +45,7 @@ t_connect(Config) when is_list(Config) ->
     fakeredis_cluster:start_link([20001, 20002, 20003]),
 
     ct:print("Perform inital connect..."),
-    ?assertMatch(ok, eredis_cluster:connect([{"127.0.0.1", 20001}])),
+    ok = eredis_cluster:connect([{"127.0.0.1", 20001}]),
 
     ct:print("Test access.."),
     ?assertEqual({ok, <<"OK">>}, eredis_cluster:q(["SET", "key", "value"])),
@@ -68,7 +68,7 @@ t_connect_tls(Config) when is_list(Config) ->
                       {keyfile,    filename:join([Dir, "client.key"])},
                       {verify,                 verify_peer},
                       {server_name_indication, "Server"}]}],
-    ?assertMatch(ok, eredis_cluster:connect([{"127.0.0.1", 20001}], Options)),
+    ok = eredis_cluster:connect([{"127.0.0.1", 20001}], Options),
 
     ct:print("Test access.."),
     ?assertEqual({ok, <<"OK">>}, eredis_cluster:q(["SET", "key", "value"])),
@@ -95,7 +95,7 @@ t_pool_full(Config) when is_list(Config) ->
     application:set_env(eredis_cluster, pool_max_overflow, 0),
 
     ct:print("Perform inital connect..."),
-    ?assertMatch(ok, eredis_cluster:connect([{"127.0.0.1", 20001}])),
+    ok = eredis_cluster:connect([{"127.0.0.1", 20001}]),
 
     ct:print("Test concurrent access..."),
     MainPid = self(),
@@ -323,7 +323,7 @@ t_eval_failure_handling(Config) when is_list(Config) ->
     %% This testcase triggers a socket disconnection right before the script loading.
     Port = 20011,
     fakeredis_cluster:start_link([Port]),
-    ?assertMatch(ok, eredis_cluster:connect([{"127.0.0.1", Port}])),
+    ok = eredis_cluster:connect([{"127.0.0.1", Port}]),
 
     Script = <<"return redis.call('SET', KEYS[1], ARGV[1]);">>,
     ScriptHash = << << if N >= 10 -> N -10 + $a; true -> N + $0 end >> || <<N:4>> <= crypto:hash(sha, Script) >>,

--- a/test/eredis_cluster_multicluster_tests.erl
+++ b/test/eredis_cluster_multicluster_tests.erl
@@ -18,25 +18,25 @@ explicit_cluster_test() ->
     %% No implicitly started default cluster
     ?assertEqual([], supervisor:which_children(eredis_cluster_sup_sup)),
 
-    ?assertEqual(ok, eredis_cluster:connect(mycluster,
-                                            [{"127.0.0.1", 31001},
-                                             {"127.0.0.1", 31002}],
-                                            tls_options())),
+    ok = eredis_cluster:connect(mycluster,
+                                [{"127.0.0.1", 31001},
+                                 {"127.0.0.1", 31002}],
+                                tls_options()),
     ?assertEqual({ok, <<"OK">>},
                  eredis_cluster:q(mycluster, ["SET", "foo", "bar"])),
     ?assertEqual({ok, <<"bar">>},
                  eredis_cluster:q(mycluster, ["GET", "foo"])),
-    ?assertMatch(ok, eredis_cluster:disconnect(mycluster)),
+    ok = eredis_cluster:disconnect(mycluster),
     ?assertMatch(ok, eredis_cluster:stop()).
 
 explicit_and_default_cluster_test() ->
     application:set_env(eredis_cluster, init_nodes, [{"127.0.0.1", 30001},
                                                      {"127.0.0.1", 30002}]),
     ?assertMatch(ok, eredis_cluster:start()),
-    ?assertEqual(ok, eredis_cluster:connect(mycluster,
-                                            [{"127.0.0.1", 31001},
-                                             {"127.0.0.1", 31002}],
-                                            tls_options())),
+    ok = eredis_cluster:connect(mycluster,
+                                [{"127.0.0.1", 31001},
+                                 {"127.0.0.1", 31002}],
+                                tls_options()),
 
     %% Both clusters are non-empty and no overlap
     Cluster1Nodes = eredis_cluster:get_all_pools(),
@@ -57,7 +57,7 @@ explicit_and_default_cluster_test() ->
                  eredis_cluster:q(mycluster, ["GET", "foo"])),
 
     %% Disconnect explicit cluster doesn't affect default cluster
-    ?assertMatch(ok, eredis_cluster:disconnect(mycluster)),
+    ok = eredis_cluster:disconnect(mycluster),
     ?assertEqual({ok, <<"bar">>},
                  eredis_cluster:q(["GET", "foo"])),
 

--- a/test/eredis_cluster_tests.erl
+++ b/test/eredis_cluster_tests.erl
@@ -129,10 +129,10 @@ basic_test_() ->
             end
             },
 
-            { "bitstring support",
+            { "binary support",
             fun () ->
-                eredis_cluster:q([<<"set">>, <<"bitstring">>,<<"support">>]),
-                ?assertEqual({ok, <<"support">>}, eredis_cluster:q([<<"GET">>, <<"bitstring">>]))
+                eredis_cluster:q([<<"set">>, <<"binary">>, <<"support">>]),
+                ?assertEqual({ok, <<"support">>}, eredis_cluster:q([<<"GET">>, <<"binary">>]))
             end
             },
 

--- a/test/eredis_cluster_tests.erl
+++ b/test/eredis_cluster_tests.erl
@@ -431,7 +431,7 @@ test_command_support(Command) ->
         {ok, [ExpectedKey | _]} ->
             ?assertEqual(binary_to_list(ExpectedKey), Key);
         {error, Error} ->
-            ?assertEqual(dummy, {Command, Error})
+            error(cmd_fail, {Command, Error})
     end.
 
 -spec get_master_nodes() -> [{NodeId::string(), PoolName::atom()}].

--- a/test/eredis_cluster_tls_tests.erl
+++ b/test/eredis_cluster_tls_tests.erl
@@ -12,9 +12,8 @@ connect_test() ->
                       {keyfile,    filename:join([Dir, "client.key"])},
                       {verify,                 verify_peer},
                       {server_name_indication, "Server"}]}],
-    Res = eredis_cluster:connect([{"127.0.0.1", 31001},
-                                  {"127.0.0.1", 31002}], Options),
-    ?assertMatch(ok, Res),
+    ok = eredis_cluster:connect([{"127.0.0.1", 31001},
+                                 {"127.0.0.1", 31002}], Options),
     ?assertMatch(ok, eredis_cluster:stop()).
 
 get_set_test() ->
@@ -40,9 +39,8 @@ options_override_test() ->
     Options = [{tls, [{cacertfile, filename:join([Dir, "ca.crt"])},
                       {certfile,   filename:join([Dir, "client.crt"])},
                       {keyfile,    filename:join([Dir, "client.key"])}]}],
-    Res = eredis_cluster:connect([{"127.0.0.1", 31001},
-                                  {"127.0.0.1", 31002}], Options),
-    ?assertMatch(ok, Res),
+    ok = eredis_cluster:connect([{"127.0.0.1", 31001},
+                                 {"127.0.0.1", 31002}], Options),
 
     Key = "Key123",
     ?assertEqual({ok, <<"OK">>}, eredis_cluster:q(["SET", Key, "value"])),
@@ -91,6 +89,5 @@ connect_tls() ->
     application:set_env(eredis_cluster, tls, [{cacertfile, filename:join([Dir, "ca.crt"])},
                                               {certfile,   filename:join([Dir, "client.crt"])},
                                               {keyfile,    filename:join([Dir, "client.key"])}]),
-    Res = eredis_cluster:connect([{"127.0.0.1", 31001},
-                                  {"127.0.0.1", 31002}]),
-    ?assertMatch(ok, Res).
+    ok = eredis_cluster:connect([{"127.0.0.1", 31001},
+                                 {"127.0.0.1", 31002}]).


### PR DESCRIPTION
Run dialyzer on the test profile during make dialyzer, and in CI runs.
This PR fixes all dialyzer warnings found in the rebar3 test profile.

Fixes #71 