### PR TITLE
Handle CLUSTER error from GCP Memorystore Redis standalone gracefully

### DIFF
--- a/src/eredis_cluster_monitor.erl
+++ b/src/eredis_cluster_monitor.erl
@@ -329,8 +329,13 @@ get_cluster_info_from_connection(Connection, Query, FailFn, Node) ->
     try eredis:q(Connection, Query) of
         {ok, ClusterInfo} ->
             {ok, ClusterInfo};
+        %% Redis Sentinel 5 or GCP Memorystore Redis
         {error, <<"ERR unknown command `CLUSTER`", _/binary>>} ->
             {ok, FailFn(Node)};
+        %% Redis Sentinel 6+
+        {error, <<"ERR unknown command 'CLUSTER'", _/binary>>} ->
+            {ok, FailFn(Node)};
+        %% Redis 5+
         {error, <<"ERR This instance has cluster support disabled">>} ->
             {ok, FailFn(Node)};
         OtherError ->

--- a/src/eredis_cluster_monitor.erl
+++ b/src/eredis_cluster_monitor.erl
@@ -329,7 +329,7 @@ get_cluster_info_from_connection(Connection, Query, FailFn, Node) ->
     try eredis:q(Connection, Query) of
         {ok, ClusterInfo} ->
             {ok, ClusterInfo};
-        {error, <<"ERR unknown command 'CLUSTER'">>} ->
+        {error, <<"ERR unknown command `CLUSTER`", _/binary>>} ->
             {ok, FailFn(Node)};
         {error, <<"ERR This instance has cluster support disabled">>} ->
             {ok, FailFn(Node)};


### PR DESCRIPTION
GCP Memorystore Redis returns a slightly different error message for the CLUSTER command when running in standalone mode:

ERR unknown command `CLUSTER`, with args beginning with: `SLOTS`,

The code currently only supports servers that return `'CLUSTER'` wrapped in single quotes and with no additional mention of args.